### PR TITLE
Support Rails 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ gemfile:
   - gemfiles/rails_50.gemfile
   - gemfiles/rails_51.gemfile
   - gemfiles/rails_52.gemfile
+  - gemfiles/rails_edge.gemfile
 
 sudo: false
 

--- a/Appraisals
+++ b/Appraisals
@@ -13,3 +13,7 @@ end
 appraise 'rails-52' do
   gem 'activerecord', '5.2.0'
 end
+
+appraise 'rails-edge' do
+  gem 'activerecord', github: 'rails/rails', branch: 'master'
+end

--- a/deferring.gemspec
+++ b/deferring.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'activerecord', ['>= 4.2', '< 5.3']
+  spec.add_dependency 'activerecord', ['>= 4.2']
 
   spec.add_development_dependency 'bundler', '~> 1.3'
   spec.add_development_dependency 'rake'

--- a/gemfiles/rails_42.gemfile
+++ b/gemfiles/rails_42.gemfile
@@ -4,4 +4,4 @@ source "https://rubygems.org"
 
 gem "activerecord", "4.2.10"
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/gemfiles/rails_42.gemfile.lock
+++ b/gemfiles/rails_42.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     deferring (0.5.0)
-      activerecord (>= 4.2, < 5.3)
+      activerecord (>= 4.2)
 
 GEM
   remote: https://rubygems.org/
@@ -63,4 +63,4 @@ DEPENDENCIES
   sqlite3
 
 BUNDLED WITH
-   1.16.2
+   1.17.1

--- a/gemfiles/rails_50.gemfile
+++ b/gemfiles/rails_50.gemfile
@@ -4,4 +4,4 @@ source "https://rubygems.org"
 
 gem "activerecord", "5.0.7"
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/gemfiles/rails_50.gemfile.lock
+++ b/gemfiles/rails_50.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     deferring (0.5.0)
-      activerecord (>= 4.2, < 5.3)
+      activerecord (>= 4.2)
 
 GEM
   remote: https://rubygems.org/
@@ -61,4 +61,4 @@ DEPENDENCIES
   sqlite3
 
 BUNDLED WITH
-   1.16.2
+   1.17.1

--- a/gemfiles/rails_51.gemfile
+++ b/gemfiles/rails_51.gemfile
@@ -4,4 +4,4 @@ source "https://rubygems.org"
 
 gem "activerecord", "5.1.6"
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/gemfiles/rails_51.gemfile.lock
+++ b/gemfiles/rails_51.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     deferring (0.5.0)
-      activerecord (>= 4.2, < 5.3)
+      activerecord (>= 4.2)
 
 GEM
   remote: https://rubygems.org/
@@ -61,4 +61,4 @@ DEPENDENCIES
   sqlite3
 
 BUNDLED WITH
-   1.16.2
+   1.17.1

--- a/gemfiles/rails_52.gemfile.lock
+++ b/gemfiles/rails_52.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     deferring (0.5.0)
-      activerecord (>= 4.2, < 5.3)
+      activerecord (>= 4.2)
 
 GEM
   remote: https://rubygems.org/
@@ -61,4 +61,4 @@ DEPENDENCIES
   sqlite3
 
 BUNDLED WITH
-   1.16.2
+   1.17.1

--- a/gemfiles/rails_edge.gemfile
+++ b/gemfiles/rails_edge.gemfile
@@ -2,6 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "activerecord", "5.2.0"
+gem "activerecord", github: "rails/rails", branch: "master"
 
 gemspec path: "../"

--- a/gemfiles/rails_edge.gemfile.lock
+++ b/gemfiles/rails_edge.gemfile.lock
@@ -1,0 +1,70 @@
+GIT
+  remote: git://github.com/rails/rails.git
+  revision: 98a75b46468c45d4477949ed267bb8823297d815
+  branch: master
+  specs:
+    activemodel (6.0.0.beta3)
+      activesupport (= 6.0.0.beta3)
+    activerecord (6.0.0.beta3)
+      activemodel (= 6.0.0.beta3)
+      activesupport (= 6.0.0.beta3)
+    activesupport (6.0.0.beta3)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+      zeitwerk (~> 2.1, >= 2.1.2)
+
+PATH
+  remote: ..
+  specs:
+    deferring (0.5.0)
+      activerecord (>= 4.2)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    appraisal (2.2.0)
+      bundler
+      rake
+      thor (>= 0.14.0)
+    concurrent-ruby (1.1.5)
+    diff-lcs (1.3)
+    i18n (1.6.0)
+      concurrent-ruby (~> 1.0)
+    minitest (5.11.3)
+    rake (12.3.2)
+    rspec (3.8.0)
+      rspec-core (~> 3.8.0)
+      rspec-expectations (~> 3.8.0)
+      rspec-mocks (~> 3.8.0)
+    rspec-core (3.8.0)
+      rspec-support (~> 3.8.0)
+    rspec-expectations (3.8.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.8.0)
+    rspec-mocks (3.8.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.8.0)
+    rspec-support (3.8.0)
+    sqlite3 (1.4.0)
+    thor (0.20.3)
+    thread_safe (0.3.6)
+    tzinfo (1.2.5)
+      thread_safe (~> 0.1)
+    zeitwerk (2.1.2)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  activerecord!
+  appraisal
+  bundler (~> 1.3)
+  deferring!
+  rake
+  rspec
+  sqlite3
+
+BUNDLED WITH
+   1.17.1


### PR DESCRIPTION
@robinroestenburg from a quick update on the test config, looks like nothing broke for the supported ruby versions. Also some updates are required for `ruby-head` regarding bundler. 

Not sure how the coverage is on the test suite, but do you think making the build pass should be enough?

This would resolve #6 